### PR TITLE
const std::string& support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(luabind)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 add_subdirectory(third_party)
 

--- a/include/luabind/mirror.hpp
+++ b/include/luabind/mirror.hpp
@@ -200,6 +200,12 @@ struct value_mirror<std::string> {
     }
 };
 
+template <>
+struct value_mirror<const std::string&> : value_mirror<std::string> {};
+
+template <>
+struct value_mirror<const std::string*> {};
+
 template <typename T, typename Y>
 struct value_mirror<std::pair<T, Y>> {
     using type = std::pair<T, Y>;

--- a/include/luabind/mirror.hpp
+++ b/include/luabind/mirror.hpp
@@ -64,7 +64,7 @@ struct value_mirror<T*> {
 template <typename T>
 struct value_mirror<T&> {
     static int to_lua(lua_State* L, T& v) {
-        value_mirror<T*>::to_lua(L, &v);
+        return value_mirror<T*>::to_lua(L, &v);
     }
 
     static T& from_lua(lua_State* L, int idx) {

--- a/include/luabind/traits.hpp
+++ b/include/luabind/traits.hpp
@@ -66,7 +66,7 @@ template <typename T>
 struct valid_lua_arg
     : std::bool_constant<!is_pointer_ref_v<T> &&
                          ((std::is_fundamental_v<T> && !std::is_pointer_v<T> && !std::is_reference_v<T>) ||
-                          std::is_class_v<T>)> {};
+                          std::is_class_v<T> || std::is_class_v<std::remove_cvref_t<T>> || std::is_class_v<std::remove_pointer<T>>)> {};
 
 } // namespace luabind
 

--- a/include/luabind/traits.hpp
+++ b/include/luabind/traits.hpp
@@ -66,7 +66,7 @@ template <typename T>
 struct valid_lua_arg
     : std::bool_constant<!is_pointer_ref_v<T> &&
                          ((std::is_fundamental_v<T> && !std::is_pointer_v<T> && !std::is_reference_v<T>) ||
-                          std::is_class_v<T> || std::is_class_v<std::remove_cvref_t<T>> || std::is_class_v<std::remove_pointer<T>>)> {};
+                           std::is_class_v<std::remove_cvref_t<T>> || std::is_class_v<std::remove_pointer<T>>)> {};
 
 } // namespace luabind
 

--- a/include/luabind/user_data.hpp
+++ b/include/luabind/user_data.hpp
@@ -95,13 +95,13 @@ template <typename T>
 struct cpp_user_data : user_data {
     T* data;
 
-    cpp_user_data(T* v)
-        : user_data(v, memory_lifetime::cpp)
+    cpp_user_data(lua_State* L, T* v)
+        : user_data(L, v, memory_lifetime::cpp)
         , data(v) {}
 
     static int to_lua(lua_State* L, T* v) {
         void* p = lua_newuserdatauv(L, sizeof(cpp_user_data), 0);
-        cpp_user_data* ud = new (p) cpp_user_data(v);
+        cpp_user_data* ud = new (p) cpp_user_data(L, v);
         if (ud->info != nullptr) {
             ud->info->get_metatable(L);
         } else {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,8 @@
 
 include(CTest)
 
-add_executable(binding binding.cpp)
+add_executable(binding binding.cpp const_binding.cpp)
 target_link_libraries(binding luabind lua gtest_main)
 
 add_test(NAME binding_test COMMAND binding)
+add_test(NAME const_binding_test COMMAND binding)

--- a/tests/binding.cpp
+++ b/tests/binding.cpp
@@ -322,7 +322,7 @@ TEST_F(LuaTest, Unbound) {
     luabind::function<&testUnboundByRef>(L, "testUnboundByRef");
     luabind::function<&testUnboundByConstRef>(L, "testUnboundByConstRef");
     luabind::function<&testUnbound>(L, "testUnbound");
-    int r = run(R"--(
+    [[maybe_unused]] int r = run(R"--(
         u = create()
         testUnboundByRef(u)
         testUnbound(u)

--- a/tests/binding.cpp
+++ b/tests/binding.cpp
@@ -6,6 +6,8 @@
 
 #include <gtest/gtest.h>
 
+#include "lua_test.hpp"
+
 class Account : public luabind::Object {
 public:
     static int count;
@@ -67,49 +69,6 @@ public:
 
 public:
     int limit = 10;
-};
-
-class LuaTest : public testing::Test {
-protected:
-    LuaTest() {
-        L = luaL_newstate();
-        luaL_openlibs(L);
-    }
-
-    ~LuaTest() override {
-        if (L != nullptr) {
-            lua_close(L);
-        }
-    }
-
-public:
-    int run(const char* script) {
-        int r = luaL_dostring(L, script);
-        if (r != LUA_OK) {
-            const char* error = lua_tostring(L, -1);
-            std::cerr << "Error: " << error << std::endl;
-        }
-        return r;
-    }
-
-    template <typename T>
-    T runWithResult(const char* script) {
-        int r = luaL_dostring(L, script);
-        if (r != LUA_OK) {
-            const char* error = lua_tostring(L, -1);
-            std::cerr << "Error: " << error << std::endl;
-            EXPECT_EQ(r, LUA_OK);
-            static T t {};
-            return t;
-        }
-        EXPECT_EQ(lua_gettop(L), 1);
-        T t = luabind::value_mirror<T>::from_lua(L, -1);
-        lua_pop(L, -1);
-        return t;
-    }
-
-protected:
-    lua_State* L = nullptr;
 };
 
 class AccountLuaTest : public LuaTest {

--- a/tests/const_binding.cpp
+++ b/tests/const_binding.cpp
@@ -1,0 +1,56 @@
+#include <iostream>
+#include <memory>
+#include <string>
+
+#include <luabind/bind.hpp>
+
+#include <gtest/gtest.h>
+
+#include "lua_test.hpp"
+
+class StringBox : public luabind::Object {
+public:
+    std::string str;
+
+public:
+    StringBox(const std::string& s)
+        : str(s) {}
+
+    void set(const std::string& s) {
+        str = s;
+    }
+
+    const std::string& get() {
+        return str;
+    }
+};
+
+class StrLuaTest : public LuaTest {
+protected:
+    void SetUp() override {
+        luabind::class_<StringBox>(L, "StringBox")
+            .constructor<const std::string&>("new")
+            .function<&StringBox::set>("set")
+            .function<&StringBox::get>("get")
+            .property<&StringBox::str>("str");
+
+        EXPECT_EQ(lua_gettop(L), 0);
+    }
+};
+
+TEST_F(StrLuaTest, StringBox) {
+    const std::string& strFromNew = runWithResult<std::string>(R"--(
+        a = StringBox:new('firstStr')
+        return a.str
+    )--");
+
+    EXPECT_EQ(strFromNew, "firstStr");
+
+    const std::string& strFromSet = runWithResult<std::string>(R"--(
+        a = StringBox:new('firstStr')
+        a:set('secondStr') 
+        return a:get()
+    )--");
+
+    EXPECT_EQ(strFromSet, "secondStr");
+}

--- a/tests/lua_test.hpp
+++ b/tests/lua_test.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+class LuaTest : public testing::Test {
+protected:
+    LuaTest() {
+        L = luaL_newstate();
+        luaL_openlibs(L);
+    }
+
+    ~LuaTest() override {
+        if (L != nullptr) {
+            lua_close(L);
+        }
+    }
+
+public:
+    int run(const char* script) {
+        int r = luaL_dostring(L, script);
+        if (r != LUA_OK) {
+            const char* error = lua_tostring(L, -1);
+            std::cerr << "Error: " << error << std::endl;
+        }
+        return r;
+    }
+
+    template <typename T>
+    T runWithResult(const char* script) {
+        int r = luaL_dostring(L, script);
+        if (r != LUA_OK) {
+            const char* error = lua_tostring(L, -1);
+            std::cerr << "Error: " << error << std::endl;
+            EXPECT_EQ(r, LUA_OK);
+            static T t {};
+            return t;
+        }
+        EXPECT_EQ(lua_gettop(L), 1);
+        T t = luabind::value_mirror<T>::from_lua(L, -1);
+        lua_pop(L, -1);
+        return t;
+    }
+
+protected:
+    lua_State* L = nullptr;
+};


### PR DESCRIPTION
Add const std::string& support. 
Add compile-time error for std::string* 
Modify valid_lua_arg to accept * types as it is supported for everything other than std::string
Move lua_test to lua_test.hpp in order to use from tests.
Add test for const std::string& binding.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PicsArt/luabind/2)
<!-- Reviewable:end -->
