### PR TITLE
Compile options should be added to luabind target's compile definition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,6 @@ set(CMAKE_CXX_STANDARD 20)
 # variable to use custom library
 set(LUA_LIB_NAME luabind_lua CACHE STRING "lua library name")
 
-set(INCLUDE_LUA_LIB_WITH_EXTERN_C ON CACHE BOOL "flag to determine whether lua library is included with extern 'C'")
-if(INCLUDE_LUA_LIB_WITH_EXTERN_C)
-    add_compile_options(-DINCLUDE_LUA_LIB_WITH_EXTERN_C)
-endif(INCLUDE_LUA_LIB_WITH_EXTERN_C)
-
 # variable to include tests to build phase
 set(LUABIND_TEST ON CACHE BOOL "variable to determine whether tests are included in build phase or not")
 
@@ -22,6 +17,12 @@ add_subdirectory(third_party)
 add_library(luabind INTERFACE)
 target_include_directories(luabind INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_link_libraries(luabind INTERFACE ${LUA_LIB_NAME})
+
+set(INCLUDE_LUA_LIB_WITH_EXTERN_C ON CACHE BOOL "flag to determine whether lua library is included with extern 'C'")
+if(INCLUDE_LUA_LIB_WITH_EXTERN_C)
+    add_compile_definitions(INCLUDE_LUA_LIB_WITH_EXTERN_C)
+    target_compile_definitions(luabind INTERFACE INCLUDE_LUA_LIB_WITH_EXTERN_C)
+endif(INCLUDE_LUA_LIB_WITH_EXTERN_C)
 
 if(LUABIND_TEST)
     enable_testing()


### PR DESCRIPTION
In order to compile luabind with INCLUDE_LUA_LIB_WITH_EXTERN_C preprocessor option the luabind target should add the macro to its compile options, otherwise when linking to luabind from outside the macro won't be set when compiling luabind's sources.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/PicsArt/luabind/4)
<!-- Reviewable:end -->
