### PR TITLE
Add read-only array access support and fix array_access template syntax

### DIFF
--- a/include/luabind/bind.hpp
+++ b/include/luabind/bind.hpp
@@ -138,7 +138,7 @@ public:
     template <auto getter>
         requires(!std::is_same_v<decltype(getter), lua_CFunction>)
     class_& array_access() {
-        return array_access(function_wrapper<decltype(getter), getter>::invoke);
+        return array_access<function_wrapper<decltype(getter), getter>::invoke>();
     }
 
     template <lua_CFunction getter>

--- a/tests/binding.cpp
+++ b/tests/binding.cpp
@@ -420,6 +420,29 @@ private:
     std::vector<int> _array;
 };
 
+class ReadOnlyArray : public luabind::Object {
+public:
+    ReadOnlyArray(std::vector<int>&& v)
+        : _array(std::move(v)) {}
+
+    int getElement(size_t idx) {
+        return _array[idx - 1];
+    }
+
+    static int ctor(lua_State* L) {
+        std::vector<int> v;
+        const int top = lua_gettop(L);
+        for (int i = 2; i <= top; ++i) {
+            v.push_back(luabind::value_mirror<int>::from_lua(L, i));
+        }
+        return luabind::value_mirror<std::shared_ptr<ReadOnlyArray>>::to_lua(
+            L, std::make_shared<ReadOnlyArray>(std::move(v)));
+    }
+
+private:
+    std::vector<int> _array;
+};
+
 class ArrayTest : public LuaTest {
 protected:
     void SetUp() override {
@@ -427,6 +450,10 @@ protected:
         luabind::class_<Array>(L, "Array")
             .constructor<&Array::ctor>("new")
             .array_access<&Array::getElement, &Array::setElement>();
+
+        luabind::class_<ReadOnlyArray>(L, "ReadOnlyArray")
+            .constructor<&ReadOnlyArray::ctor>("new")
+            .array_access<&ReadOnlyArray::getElement>();
 
         // clang-format on
         EXPECT_EQ(lua_gettop(L), 0);
@@ -453,6 +480,27 @@ TEST_F(ArrayTest, ArrayAccess) {
         assert(a[3] == 8)
         assert(a[4] == 9)
         assert(a[5] == 10)
+    )--");
+    EXPECT_EQ(r, LUA_OK);
+}
+
+TEST_F(ArrayTest, ReadOnlyArrayAccess) {
+    int r = run(R"--(
+        ro = ReadOnlyArray:new(1, 2, 3, 4, 5);
+        -- Test that we can read from read-only array
+        assert(ro[1] == 1)
+        assert(ro[2] == 2)
+        assert(ro[3] == 3)
+        assert(ro[4] == 4)
+        assert(ro[5] == 5)
+        
+        -- Test that writing to read-only array fails
+        local success, err = pcall(function() ro[1] = 10 end)
+        assert(not success)
+        assert(string.find(err, "does not provide array set access"))
+        
+        -- Verify values are unchanged
+        assert(ro[1] == 1)
     )--");
     EXPECT_EQ(r, LUA_OK);
 }


### PR DESCRIPTION
- Fix template syntax in single-parameter array_access() method by adding missing <> around function wrapper.

- Add ReadOnlyArray class and test demonstrating read-only array access using array_access<getter>() without setter. Test validates read access works, and write access properly fails with appropriate error message.